### PR TITLE
Fix PHP warning for undeclared $status variable

### DIFF
--- a/sleeky-frontend/index.php
+++ b/sleeky-frontend/index.php
@@ -40,7 +40,7 @@ include 'header.php';
 ?>
 
 	
-<?php if( $status == 'success' ):  ?>
+<?php if( isset($status) && $status == 'success' ):  ?>
 
 	<?php $url = preg_replace("(^https?://)", "", $shorturl );  ?>
 


### PR DESCRIPTION
$status does not exist unless the form has been submitted. Status is not set and throws a warning when visiting the main frontend. This commit fixes warning.