### PR TITLE
Fixed broken frontend CSS link

### DIFF
--- a/sleeky-frontend/header.php
+++ b/sleeky-frontend/header.php
@@ -16,10 +16,10 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400|Montserrat:400,700' rel='stylesheet' type='text/css'>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 
-    <link rel="stylesheet" href="<?php echo siteURL ?>assets/css/base.css">
-    <link rel="stylesheet" href="<?php echo siteURL ?>assets/css/mobile.css">
-    <link rel="stylesheet" href="<?php echo siteURL ?>assets/css/tablet.css">
-    <link rel="stylesheet" href="<?php echo siteURL ?>assets/css/desktop.css">
+    <link rel="stylesheet" href="<?php echo siteURL ?>/assets/css/base.css">
+    <link rel="stylesheet" href="<?php echo siteURL ?>/assets/css/mobile.css">
+    <link rel="stylesheet" href="<?php echo siteURL ?>/assets/css/tablet.css">
+    <link rel="stylesheet" href="<?php echo siteURL ?>/assets/css/desktop.css">
 
     <?php if (defined('backgroundImage')) : ?>
       <style>


### PR DESCRIPTION
Link to stylesheets requires a slash after the siteURL. Otherwise, it will be linking example.comassets/css/base.css