### PR TITLE
Manage admin links in PHP

### DIFF
--- a/sleeky-backend/assets/js/theme.js
+++ b/sleeky-backend/assets/js/theme.js
@@ -110,9 +110,6 @@ $( document ).ready(function() {
     // Add mobile nav hamburger
     $("#wrap").prepend(`<div class="nav-open" id="navOpen"><i class="material-icons">menu</i></div>`);
 
-    // Add frontend link
-    $('#admin_menu').append('<li class="admin_menu_toplevel frontend_link"><a href="/"><i class="material-icons">arrow_back</i> Frontend Interface</a></li>');
-
     // admin_menu
     $('#navOpen').on('click', function() {
       $('#admin_menu').slideToggle();

--- a/sleeky-backend/plugin.php
+++ b/sleeky-backend/plugin.php
@@ -139,9 +139,21 @@ function sleeky_settings_update() {
 	}
 }
 
-// Hide admin links for non-authenticated users
-if (yourls_is_valid_user() != 1) {
-	echo <<<HEAD
-		<style>ul#admin_menu li:not(.frontend_link) {display: none}</style>
-HEAD;
+/*
+ * Remove admin links for non-authenticated users
+*/
+yourls_add_filter('admin_links', 'sleeky_admin_links');
+function sleeky_admin_links($links)
+{
+    if (true !== yourls_is_valid_user()) {
+        $links = [];
+    }
+
+    $links['frontend_link'] = [
+        'url'    => yourls_site_url(false, '/'),
+        'title'  => yourls__( 'Frontend Interface' ),
+        'anchor' => '<i class="material-icons">arrow_back</i> ' . yourls__( 'Frontend Interface' )
+    ];
+
+    return $links;
 }


### PR DESCRIPTION
This MR moves the JS/CSS changes performed in the admin menu to a single filter in PHP.

It brings following benefits:
* Outputting the `<style>` tag was breaking most XHR calls
* Adding the frontend link in PHP makes it translatable and more flexible (it will generate a link to the frontend even if it isn't the root of the current domain being viewed)