### PR TITLE
Update clipboard.js to 2.0.6

### DIFF
--- a/sleeky-frontend/frontend/header.php
+++ b/sleeky-frontend/frontend/header.php
@@ -54,7 +54,7 @@
       </style>
     <?php endif; ?>
 
-    <script src="https://cdn.jsdelivr.net/clipboard.js/1.5.5/clipboard.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
 
     <!-- Add extra support of older browsers -->
     <!--[if lt IE 9]>

--- a/sleeky-frontend/index.php
+++ b/sleeky-frontend/index.php
@@ -95,7 +95,7 @@
 	</section>
 
     <script>
-	    var clipboard = new Clipboard('.short-url-button');
+	    var clipboard = new ClipboardJS('.short-url-button');
     </script>
 
 <?php else: ?>


### PR DESCRIPTION
The only breaking change since v1.6.1 was the change to the constructor from `new Clipboard()` to `new ClipboardJS()` in [v2.0.0](https://github.com/zenorocha/clipboard.js/releases/tag/v2.0.0).