### PR TITLE
header.php: Update clipboard.js to v2.0.8 and add SRI hashes

### DIFF
--- a/sleeky-frontend/frontend/header.php
+++ b/sleeky-frontend/frontend/header.php
@@ -54,12 +54,12 @@
       </style>
     <?php endif; ?>
 
-    <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.8/dist/clipboard.min.js" integrity="sha512-sIqUEnRn31BgngPmHt2JenzleDDsXwYO+iyvQ46Mw6RL+udAUZj2n/u/PGY80NxRxynO7R9xIGx5LEzw4INWJQ==" crossorigin="anonymous"></script>
 
     <!-- Add extra support of older browsers -->
     <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js" integrity="sha512-xay60hbqdH7N5W+TBcPxupebVU7o/2G5j+cDkLNS2CSbzJ2+vbzlBP6PqF3ZHTTFDfAWFfmOz93/N8YJ5YkhjA==" crossorigin="anonymous"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js" integrity="sha512-IvQusQF5BtnzHhcWCL3w+ItYY6fn+g4bo24AyKlQa7FxpE8A41kIX4xmC+H67jbKFcmiLtgwX3UBnF9t+4oO3A==" crossorigin="anonymous"></script>
     <![endif]-->
 
   </head>


### PR DESCRIPTION
The pull request which updated `clipboard.js` to v2.0.6 was submitted back in November 2020, so there have been a couple new minor releases since then. I think it's also prudent to add SRI hashes since we're fetching resources from CDNs here.