### PR TITLE
Added possibility to require authorization before shortening is possible

### DIFF
--- a/sleeky-frontend/frontend/config.php
+++ b/sleeky-frontend/frontend/config.php
@@ -28,6 +28,11 @@ define("recaptchaV3SiteKey", 'YOUR_SITE_KEY_HERE');
 // reCAPTCHA V3 Secret Key
 define("recaptchaV3SecretKey", 'YOUR_SECRET_KEY_HERE');
 
+// Enable authentication requirement for shortening links
+// true = only authenticated users can shorten, false = anyone can shorten
+// default: false
+define('requireAuth', false);
+
 // Enables the custom URL field
 // true or false
 define('enableCustomURL', true);


### PR DESCRIPTION
I've added the ability to require authorization for the public facing shortening page. 
It's configurable in config.php and is not enabled by default. 

I also fixed a typo... 

<img width="707" height="563" alt="grafik" src="https://github.com/user-attachments/assets/6db9e839-4664-4564-b654-7c8c06fc7cf6" />

After logging in with user credentials defined in the yourls config file (`users/config.php`) 

<img width="740" height="454" alt="grafik" src="https://github.com/user-attachments/assets/86035c5b-a847-4d71-889c-536e2395509b" />



